### PR TITLE
Correctly read properties with spaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,14 @@ jobs:
     - name: Verify second property has been read correctly
       if: steps.read_second_property.outputs.value != 'foobar'
       run: exit 1
+
+    # test 4: properties with spaces around the equals sign.
+    - name: Read property with spaces
+      id: read_property_with_spaces
+      uses: ./
+      with:
+        path: './test/foo.properties'
+        property: 'with.space'
+    - name: Verify property with spaces has been read correctly
+      if: steps.read_property_with_spaces.outputs.value != '42'
+      run: exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,9 @@ main() {
   echo "path to properties-file: $path"
   echo "property key: $property"
 
-  result=$(sed -n "/^$property=/s/$property=//p" "$path")
+  # For lines that have the given property on the left-hand side, remove 
+  # the property name, the equals and any spaces to get the property value.
+  result=$(sed -n "/^[[:space:]]*$property[[:space:]]*=[[:space:]]*/s/^[[:space:]]*$property[[:space:]]*=[[:space:]]*//p" "$path")
 
   echo "property value: $result"
   echo ::set-output name=value::"$result"

--- a/test/foo.properties
+++ b/test/foo.properties
@@ -1,7 +1,7 @@
 foo=bar
 foo.bar=foobar
 foo.bar.foo=foo bar
-with.space = value of equal and space
+with.space = 42
 
 FOO_BAR=value of screaming snake case prop
 


### PR DESCRIPTION
Currently, the action is not able to read properties if there are spaces around the property definition and the equals. With this code, the regex will correctly match even if there are spaces, and all spaces between the start of the line and the start of the property value will be removed.

Also add a unit test for this case.

I know it looks a bit ugly, but I didn't want to use the extended regular expression syntax because it's different for Linux and Mac OS X, and I am writing / testing it on Mac OS X.

This works on both Linux and Mac OS X.