### PR TITLE
Support reading multiple properties

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,11 @@ jobs:
       uses: ./
       with:
         path: './test/foo.properties'
-        property: 'foo'
+        properties: 'foo'
     - name: Do something with the property value
-      run: echo ${{ steps.read_first_property.outputs.value }}
+      run: echo ${{ steps.read_first_property.outputs.foo }}
     - name: Verify first property has been read correctly
-      if: steps.read_first_property.outputs.value != 'bar'
+      if: steps.read_first_property.outputs.foo != 'bar'
       run: exit 1
 
     # test 2
@@ -29,9 +29,9 @@ jobs:
       uses: ./
       with:
         path: './test/foo.properties'
-        property: 'foo.bar.foo'
+        properties: 'foo.bar.foo'
     - name: Verify third property has been read correctly
-      if: steps.read_third_property.outputs.value != 'foo bar'
+      if: steps.read_third_property.outputs.foo-bar-foo != 'foo bar'
       run: exit 1
 
       # test 3
@@ -40,9 +40,9 @@ jobs:
       uses: ./
       with:
         path: './test/foo.properties'
-        property: 'foo.bar'
+        properties: 'foo.bar'
     - name: Verify second property has been read correctly
-      if: steps.read_second_property.outputs.value != 'foobar'
+      if: steps.read_second_property.outputs.foo-bar != 'foobar'
       run: exit 1
 
     # test 4: properties with spaces around the equals sign.
@@ -51,7 +51,19 @@ jobs:
       uses: ./
       with:
         path: './test/foo.properties'
-        property: 'with.space'
+        properties: 'with.space'
     - name: Verify property with spaces has been read correctly
-      if: steps.read_property_with_spaces.outputs.value != '42'
+      if: steps.read_property_with_spaces.outputs.with-space != '42'
+      run: exit 1
+
+    # test 5: read multiple properties
+    - name: Read multiple properties
+      id: read_multiple_properties
+      uses: ./
+      with:
+        path: './test/foo.properties'
+        properties: 'foo foo.bar'
+    - name: Verify multiple properties have been read correctly
+      if: steps.read_multiple_properties.outputs.foo != 'bar'
+        || steps.read_multiple_properties.outputs.foo-bar != 'foobar'
       run: exit 1

--- a/README.md
+++ b/README.md
@@ -14,15 +14,13 @@ This is a GitHub action to read from java `.properties` files.
 
 **Required** The path to properties file to read.
 
-### `property`
+### `properties`
 
-**Required** The property you want to read.
+**Required** The properties you want to read. Space separated
 
 ## Outputs
 
-### `value`
-
-The value of the given property.
+For each provided property, one output of the same name exists. Because the names of outputs can only contain alphanumeric characters, `-` and `_`, any other character is replaced by a `-`.
 
 ## Example usage
 
@@ -31,10 +29,10 @@ The value of the given property.
       uses: christian-draeger/read-properties@1.0.1
       with:
         path: './src/main/resources/application.properties'
-        property: 'the.key.of.the.property'
+        properties: 'the.key.of.a.property the.key.of.another.property'
     - name: Do something with your bumped release version
-      run: echo ${{ steps.read_property.outputs.value }}
-      # will print "the value of 'the.key.of.the.property'"
+      run: echo ${{ steps.read_property.outputs.the-key-of-a-property }}
+      # will print "the value of 'the.key.of.a.property'"
 
 # License
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -8,15 +8,12 @@ inputs:
   path:
     description: 'The path to properties file to read'
     required: true
-  property:
-    description: 'The property you want to read'
+  properties:
+    description: 'The properties you want to read. Space separated'
     required: true
-outputs:
-  value:
-    description: 'The value of the given property'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.path }}
-    - ${{ inputs.property }}
+    - ${{ inputs.properties }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,21 +15,24 @@ set -euo pipefail
 main() {
 
   local path
-  local property
+  local properties
   local result
 
   path="$1"
-  property="$2"
+  properties="$2"
 
   echo "path to properties-file: $path"
-  echo "property key: $property"
+  echo "property keys: $properties"
 
-  # For lines that have the given property on the left-hand side, remove 
-  # the property name, the equals and any spaces to get the property value.
-  result=$(sed -n "/^[[:space:]]*$property[[:space:]]*=[[:space:]]*/s/^[[:space:]]*$property[[:space:]]*=[[:space:]]*//p" "$path")
+  for key in $properties; do
+    # For lines that have the given property on the left-hand side, remove
+    # the property name, the equals and any spaces to get the property value.
+    result=$(sed -n "/^[[:space:]]*$key[[:space:]]*=[[:space:]]*/s/^[[:space:]]*$key[[:space:]]*=[[:space:]]*//p" "$path")
 
-  echo "property value: $result"
-  echo ::set-output name=value::"$result"
+    echo "value of '$key': $result"
+    # shellcheck disable=SC2001
+    echo "::set-output name=$(echo "$key" | sed 's/[^A-Za-z0-9_]/-/g')::$result"
+  done
 }
 
 main "$1" "$2"


### PR DESCRIPTION
This PR adds support for reading multiple properties. The following was changed:

- `property` input was renamed to `properties` and now accepts a space separated list of property keys
- The `value` output was removed and instead there is one output for each property with a matching name

When merged, this closes #2.