### PR TITLE
Deprecating save-state and set-output commands -- update

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ main() {
 
     echo "value of '$key': $result"
     # shellcheck disable=SC2001
-    echo "::set-output name=$(echo "$key" | sed 's/[^A-Za-z0-9_]/-/g')::$result"
+    echo "$(echo "$key" | sed 's/[^A-Za-z0-9_]/-/g')=$result" >> $GITHUB_OUTPUT
   done
 }
 


### PR DESCRIPTION
GitHub Actions: Deprecating save-state and set-output commands
Action and workflow authors who are using save-state or set-output via stdout should update to use the new [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/